### PR TITLE
Fix websocket url formation

### DIFF
--- a/frontend/src/apiService.js
+++ b/frontend/src/apiService.js
@@ -227,7 +227,10 @@ class ApiService {
 
   // WebSocket connection using your backend's /ws endpoint
   connectWebSocket(onMessage, onError) {
-    const wsURL = this.baseURL.replace('http://localhost:8080', 'ws://localhost:8080') + '/ws';
+    // Support any baseURL by converting the protocol to WS/WSS
+    const urlObj = new URL(this.baseURL);
+    const wsProtocol = urlObj.protocol === 'https:' ? 'wss:' : 'ws:';
+    const wsURL = `${wsProtocol}//${urlObj.host}/ws`;
     console.log('Connecting to WebSocket:', wsURL);
     
     const ws = new WebSocket(wsURL);


### PR DESCRIPTION
## Summary
- improve websocket URL construction to handle any base URL

## Testing
- `npm test --silent --forceExit` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843129e7c848329b534baf3b904d56f