### PR TITLE
Add npm install step for frontend tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,8 +317,10 @@ go test ./...
 
 # Frontend tests
 cd frontend
+npm install # install dependencies including react-scripts
 npm test
 ```
+> **Note**: `react-scripts` must be installed. Run `npm install` in the `frontend/` directory before executing `npm test`.
 
 ### Building for Production
 


### PR DESCRIPTION
## Summary
- document that running tests requires `npm install` in the `frontend` directory
- mention `react-scripts` dependency

## Testing
- `npm test` *(fails: react-scripts not found)*
- `go test ./...` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684329a4703c83299c513d9f4f477e0b