### PR TITLE
Remove obsolete services.go

### DIFF
--- a/backend/services.go
+++ b/backend/services.go
@@ -1,1 +1,0 @@
-package main


### PR DESCRIPTION
## Summary
- delete empty backend/services.go file since rate limiting and client management now live in monitor.go

## Testing
- `env GOTOOLCHAIN=local go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684329a479fc8329aac733a594aff0e9