### PR TITLE
Fix npm start to run dev server

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "start": "vite"
   },
   "dependencies": {
     "lucide-react": "^0.511.0",


### PR DESCRIPTION
## Summary
- add `start` script in frontend package.json to run dev server

## Testing
- `npm run --silent help 2>/dev/null | head -n 20 || true`


------
https://chatgpt.com/codex/tasks/task_e_685303f555bc83299b1bd0c9276504b5